### PR TITLE
Publish kotlin library to maven central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
       run: ./gradlew test
       
     - name: Publish to Maven Central
-      run: ./gradlew publishAllPublicationsToMavenCentralRepository
+      run: ./gradlew publishToMavenCentral
         
     - name: Close and release repository
       run: ./gradlew closeAndReleaseRepository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,5 @@ jobs:
     - name: Run tests
       run: ./gradlew test
       
-    - name: Publish to Maven Central
-      run: ./gradlew publishToMavenCentral
-        
-    - name: Close and release repository
-      run: ./gradlew closeAndReleaseRepository
+    - name: Publish and release to Maven Central
+      run: ./gradlew publishAndReleaseToMavenCentral

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,37 +31,26 @@ jobs:
           
     - name: Make gradlew executable
       run: chmod +x ./gradlew
-      
-    - name: Decode GPG key
-      run: |
-        echo "${{ secrets.SIGNING_KEY }}" | base64 --decode | gpg --import --batch --yes
-        
-    - name: Get GPG key ID
-      id: gpg-key-id
-      run: |
-        echo "keyid=$(gpg --list-secret-keys --keyid-format=long | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)" >> $GITHUB_OUTPUT
         
     - name: Configure Gradle for publishing
       run: |
         echo "ossrhUsername=${{ secrets.OSSRH_USERNAME }}" >> gradle.properties
         echo "ossrhPassword=${{ secrets.OSSRH_PASSWORD }}" >> gradle.properties
-        echo "signing.keyId=${{ steps.gpg-key-id.outputs.keyid }}" >> gradle.properties
-        echo "signing.password=${{ secrets.SIGNING_PASSWORD }}" >> gradle.properties
-        echo "signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg" >> gradle.properties
+
+    - name: Configure in-memory signing
+      run: |
+        echo "ORG_GRADLE_PROJECT_signingInMemoryKey<<EOF" >> $GITHUB_ENV
+        echo "${{ secrets.SIGNING_KEY }}" | base64 --decode >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+        echo "ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}" >> $GITHUB_ENV
+        echo "ORG_GRADLE_PROJECT_mavenCentralUsername=${{ secrets.OSSRH_USERNAME }}" >> $GITHUB_ENV
+        echo "ORG_GRADLE_PROJECT_mavenCentralPassword=${{ secrets.OSSRH_PASSWORD }}" >> $GITHUB_ENV
         
     - name: Run tests
       run: ./gradlew test
       
     - name: Publish to Maven Central
       run: ./gradlew publishAllPublicationsToMavenCentralRepository
-      env:
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-        SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
         
     - name: Close and release repository
       run: ./gradlew closeAndReleaseRepository
-      env:
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: Publish to Maven Central
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        
+    - name: Cache Gradle packages
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+          
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+      
+    - name: Decode GPG key
+      run: |
+        echo "${{ secrets.SIGNING_KEY }}" | base64 --decode | gpg --import --batch --yes
+        
+    - name: Get GPG key ID
+      id: gpg-key-id
+      run: |
+        echo "keyid=$(gpg --list-secret-keys --keyid-format=long | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)" >> $GITHUB_OUTPUT
+        
+    - name: Configure Gradle for publishing
+      run: |
+        echo "ossrhUsername=${{ secrets.OSSRH_USERNAME }}" >> gradle.properties
+        echo "ossrhPassword=${{ secrets.OSSRH_PASSWORD }}" >> gradle.properties
+        echo "signing.keyId=${{ steps.gpg-key-id.outputs.keyid }}" >> gradle.properties
+        echo "signing.password=${{ secrets.SIGNING_PASSWORD }}" >> gradle.properties
+        echo "signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg" >> gradle.properties
+        
+    - name: Run tests
+      run: ./gradlew test
+      
+    - name: Publish to Maven Central
+      run: ./gradlew publishAllPublicationsToMavenCentralRepository
+      env:
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        
+    - name: Close and release repository
+      run: ./gradlew closeAndReleaseRepository
+      env:
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,11 +32,6 @@ jobs:
     - name: Make gradlew executable
       run: chmod +x ./gradlew
         
-    - name: Configure Gradle for publishing
-      run: |
-        echo "ossrhUsername=${{ secrets.OSSRH_USERNAME }}" >> gradle.properties
-        echo "ossrhPassword=${{ secrets.OSSRH_PASSWORD }}" >> gradle.properties
-
     - name: Configure in-memory signing
       run: |
         echo "ORG_GRADLE_PROJECT_signingInMemoryKey<<EOF" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Kai is a minimal, elegant library for building and managing AI agents in Kotlin.
 
 ```kotlin
 dependencies {
-    implementation("io.kai:kai:1.0.0")
+    implementation("io.github.neuraquant:kai:1.0.0")
 }
 ```
 
@@ -25,18 +25,43 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'io.kai:kai:1.0.0'
+    implementation 'io.github.neuraquant:kai:1.0.0'
 }
+```
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>io.github.neuraquant</groupId>
+    <artifactId>kai</artifactId>
+    <version>1.0.0</version>
+</dependency>
 ```
 
 ### Building from Source
 
 ```bash
-git clone https://github.com/yourusername/kai.git
+git clone https://github.com/NeuraQuant/kai.git
 cd kai
 ./gradlew build
 ./gradlew publishToMavenLocal
 ```
+
+## Publishing
+
+This library is automatically published to Maven Central on every merge to the main branch using GitHub Actions. The publishing process includes:
+
+- **Automated Testing**: All tests must pass before publishing
+- **GPG Signing**: All artifacts are signed with our GPG key
+- **Maven Central**: Published to `io.github.neuraquant:kai`
+- **Version Management**: Versions are managed through the `version` property in `build.gradle.kts`
+
+### Available on Maven Central
+
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.neuraquant/kai.svg)](https://search.maven.org/artifact/io.github.neuraquant/kai)
+
+The library is available at: https://search.maven.org/artifact/io.github.neuraquant/kai
 
 ## Quick Start
 
@@ -451,6 +476,43 @@ kai/
 - **Extensible**: Easy to add custom clients, tools, and behaviors
 - **Lightweight**: Minimal dependencies, fast compilation
 
+## CI/CD
+
+This project uses GitHub Actions for automated publishing to Maven Central:
+
+- **Trigger**: Automatically runs on every push to the `main` branch
+- **Testing**: Runs all tests before publishing
+- **Signing**: GPG signs all artifacts using organization secrets
+- **Publishing**: Publishes to Maven Central (Sonatype S01)
+- **Release**: Automatically closes and releases the repository
+
+### Workflow Details
+
+The publishing workflow (`.github/workflows/publish.yml`) handles:
+- JDK 17 setup and Gradle caching
+- GPG key import and configuration
+- Sonatype credentials management
+- Automated testing and validation
+- Maven Central publishing and release
+
+### Required Secrets
+
+The following secrets must be configured in the GitHub organization:
+- `OSSRH_USERNAME`: Sonatype username
+- `OSSRH_PASSWORD`: Sonatype password/token
+- `SIGNING_KEY`: GPG private key (base64 encoded)
+- `SIGNING_PASSWORD`: GPG key passphrase
+
 ## License
 
-MIT License - see LICENSE file for details
+MIT License - see [LICENSE](LICENSE) file for details
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests if applicable
+5. Submit a pull request
+
+The library will be automatically published to Maven Central once your changes are merged to the main branch.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") version "1.9.22"
     kotlin("plugin.serialization") version "1.9.22"
-    `maven-publish`
+    id("com.vanniktech.maven.publish") version "0.25.3"
 }
 
-group = "io.kai"
+group = "io.github.neuraquant"
 version = "1.0.0"
 
 repositories {
@@ -35,30 +35,38 @@ java {
     withSourcesJar()
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-            
-            pom {
-                name.set("Kai")
-                description.set("Lightweight utility library for structuring and managing Agentic AI agents")
-                url.set("https://github.com/NeuraQuant/kai")
-                
-                licenses {
-                    license {
-                        name.set("MIT License")
-                        url.set("https://opensource.org/licenses/MIT")
-                    }
-                }
+mavenPublishing {
+    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.S01, true)
+    
+    signAllPublications()
+    
+    coordinates("io.github.neuraquant", "kai", version.toString())
+    
+    pom {
+        name.set("Kai")
+        description.set("Lightweight utility library for structuring and managing Agentic AI agents")
+        inceptionYear.set("2024")
+        url.set("https://github.com/NeuraQuant/kai")
+        
+        licenses {
+            license {
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
             }
         }
-    }
-    
-    repositories {
-        maven {
-            name = "local"
-            url = uri(layout.buildDirectory.dir("repo"))
+        
+        developers {
+            developer {
+                id.set("neuraquant")
+                name.set("NeuraQuant")
+                url.set("https://github.com/NeuraQuant")
+            }
+        }
+        
+        scm {
+            url.set("https://github.com/NeuraQuant/kai")
+            connection.set("scm:git:git://github.com/NeuraQuant/kai.git")
+            developerConnection.set("scm:git:ssh://git@github.com/NeuraQuant/kai.git")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,8 +44,8 @@ mavenPublishing {
     
     pom {
         name.set("Kai")
-        description.set("Lightweight utility library for structuring and managing Agentic AI agents")
-        inceptionYear.set("2024")
+        description.set("Lightweight Kotlin utility library for structuring and managing Agentic AI")
+        inceptionYear.set("2025")
         url.set("https://github.com/NeuraQuant/kai")
         
         licenses {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,20 @@
+# Gradle properties for Maven Central publishing
+# These will be overridden by GitHub Actions secrets
+
+# Sonatype credentials (set via GitHub Actions secrets)
+ossrhUsername=
+ossrhPassword=
+
+# GPG signing configuration (set via GitHub Actions secrets)
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=
+
+# Gradle configuration
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true
+
+# Kotlin configuration
+kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,3 @@
-# Gradle properties for Maven Central publishing
-# These will be overridden by GitHub Actions secrets
-
-# Sonatype credentials (set via GitHub Actions secrets)
-ossrhUsername=
-ossrhPassword=
-
-# GPG signing configuration (set via GitHub Actions secrets)
-signing.keyId=
-signing.password=
-signing.secretKeyRingFile=
-
 # Gradle configuration
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.parallel=true


### PR DESCRIPTION
Set up automated publishing to Maven Central for the Kotlin library using `gradle-maven-publish-plugin` and GitHub Actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-86581353-38d4-44c6-b7d8-350982bfafad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-86581353-38d4-44c6-b7d8-350982bfafad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

