### PR TITLE
Direct to main deployment pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         
     - name: Verify Java version
@@ -133,6 +133,8 @@ jobs:
           echo "ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}"
           echo "ORG_GRADLE_PROJECT_mavenCentralUsername=${{ secrets.OSSRH_USERNAME }}"
           echo "ORG_GRADLE_PROJECT_mavenCentralPassword=${{ secrets.OSSRH_PASSWORD }}"
+          echo "ORG_GRADLE_PROJECT_sonatypeUsername=${{ secrets.OSSRH_USERNAME }}"
+          echo "ORG_GRADLE_PROJECT_sonatypePassword=${{ secrets.OSSRH_PASSWORD }}"
         } >> "$GITHUB_ENV"
         
         echo "✅ Environment variables configured successfully"
@@ -141,6 +143,11 @@ jobs:
       run: |
         echo "🧪 Running tests..."
         ./gradlew test --info
+        
+    - name: Build project
+      run: |
+        echo "🔨 Building project..."
+        ./gradlew build --info
       
     - name: Publish and release to Maven Central
       run: |
@@ -148,16 +155,15 @@ jobs:
         echo "📋 Available environment variables:"
         echo "  - ORG_GRADLE_PROJECT_mavenCentralUsername: ${ORG_GRADLE_PROJECT_mavenCentralUsername:+SET}"
         echo "  - ORG_GRADLE_PROJECT_mavenCentralPassword: ${ORG_GRADLE_PROJECT_mavenCentralPassword:+SET}"
+        echo "  - ORG_GRADLE_PROJECT_sonatypeUsername: ${ORG_GRADLE_PROJECT_sonatypeUsername:+SET}"
+        echo "  - ORG_GRADLE_PROJECT_sonatypePassword: ${ORG_GRADLE_PROJECT_sonatypePassword:+SET}"
         echo "  - ORG_GRADLE_PROJECT_signingInMemoryKey: ${ORG_GRADLE_PROJECT_signingInMemoryKey:+SET}"
         echo "  - ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${ORG_GRADLE_PROJECT_signingInMemoryKeyPassword:+SET}"
         
         echo "🔍 Checking Gradle properties:"
-        ./gradlew properties | grep -E "(mavenCentral|signing)" || echo "No mavenCentral or signing properties found"
+        ./gradlew properties | grep -E "(mavenCentral|signing|sonatype)" || echo "No mavenCentral or signing properties found"
         
         echo "📦 Publishing to Maven Central..."
         ./gradlew publishAllPublicationsToMavenCentralRepository --info --stacktrace
-        
-        echo "🚀 Closing and releasing repository..."
-        ./gradlew closeAndReleaseRepository --info --stacktrace
         
         echo "✅ Publishing completed successfully!"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,12 +26,12 @@ tasks.test {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "17"
+    kotlinOptions.jvmTarget = "21"
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
     // Don't create sources jar here as we'll use kotlinSourcesJar instead
 }
 
@@ -79,5 +79,10 @@ afterEvaluate {
     tasks.named("generateMetadataFileForMavenPublication") {
         dependsOn("kotlinSourcesJar")
     }
+}
+
+// Ensure proper task ordering for publishing
+tasks.named("publishAllPublicationsToMavenCentralRepository") {
+    dependsOn("test")
 }
 


### PR DESCRIPTION
Fixes the broken GitHub Actions workflow by updating Java to 21, correcting Maven Central publishing credentials, and streamlining the build and publish steps.

The previous workflow failed due to an incorrect Java version, missing required Sonatype credentials for the publishing plugin, and an attempt to call a non-existent `closeAndReleaseRepository` task. This PR updates the Java version, provides the necessary Sonatype credentials, adds a dedicated build step, and ensures tests run before publishing, resolving these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b26a35d-18f6-4790-8dd7-03c1cb9692e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b26a35d-18f6-4790-8dd7-03c1cb9692e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

