### PR TITLE
Fix staging repository creation error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,7 +157,4 @@ jobs:
         echo "📦 Publishing to Maven Central..."
         ./gradlew publishAllPublicationsToMavenCentralRepository --info --stacktrace
         
-        echo "🚀 Closing and releasing repository..."
-        ./gradlew closeAndReleaseRepository --info --stacktrace
-        
         echo "✅ Publishing completed successfully!"


### PR DESCRIPTION
Remove redundant `closeAndReleaseRepository` task from publish workflow to fix build failures caused by automatic Maven Central release.

The `publishToMavenCentral` configuration in `build.gradle.kts` with `true` as the second parameter already handles the automatic creation, closing, and releasing of the staging repository. The separate `closeAndReleaseRepository` task was redundant and failed because the repository was already released, conflicting with the intended design of no separate staging environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-114edc5f-dd96-4f9a-91a0-7972c6f64699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-114edc5f-dd96-4f9a-91a0-7972c6f64699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

