### PR TITLE
Debug new build pipeline error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,24 +118,24 @@ jobs:
       run: |
         echo "🔐 Validating GPG signing credentials..."
         
-        # Check if key is base64 encoded or raw GPG key
-        if echo "${{ secrets.SIGNING_KEY }}" | base64 --decode > /dev/null 2>&1; then
-          echo "🔓 Decoding base64 encoded GPG key..."
-          SIGNING_KEY_CONTENT=$(echo "${{ secrets.SIGNING_KEY }}" | base64 --decode)
-        else
+        # Check if key is raw GPG key (starts with PGP header) or base64 encoded
+        if echo "${{ secrets.SIGNING_KEY }}" | grep -q "BEGIN PGP PRIVATE KEY BLOCK"; then
           echo "📝 Using raw GPG key format..."
           SIGNING_KEY_CONTENT="${{ secrets.SIGNING_KEY }}"
+        else
+          echo "🔓 Decoding base64 encoded GPG key..."
+          SIGNING_KEY_CONTENT=$(echo "${{ secrets.SIGNING_KEY }}" | base64 --decode)
         fi
         
         # Import GPG key to verify it's valid
-        echo "$SIGNING_KEY_CONTENT" | gpg --batch --import 2>&1 | tee /tmp/gpg_import.log
-        
-        if [ ${PIPESTATUS[1]} -ne 0 ]; then
+        if ! echo "$SIGNING_KEY_CONTENT" | gpg --batch --import 2>&1 | tee /tmp/gpg_import.log; then
           echo "❌ ERROR: Failed to import GPG signing key"
           echo "   The SIGNING_KEY secret appears to be invalid or corrupted"
           echo "   Please verify:"
           echo "   1. The key was exported correctly: gpg --armor --export-secret-keys <key-id>"
           echo "   2. If base64 encoded, it was encoded correctly: ... | base64 -w 0"
+          echo ""
+          echo "GPG import output:"
           cat /tmp/gpg_import.log
           exit 1
         fi


### PR DESCRIPTION
Fix GPG signing credentials validation in publish workflow to correctly detect key format and improve error checking.

The previous validation logic for the `SIGNING_KEY` secret was flawed. It incorrectly assumed a key was base64 encoded if `base64 --decode` succeeded (which it does even for non-base64 input), and used an unreliable `PIPESTATUS[1]` check for the GPG import. This PR corrects the key format detection and uses a more robust error check.

---
<a href="https://cursor.com/background-agent?bcId=bc-6352628f-09c1-479b-9897-537871c55a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6352628f-09c1-479b-9897-537871c55a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

